### PR TITLE
Fix submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "googletest"]
 	path = googletest
-	url = git://github.com/hazelnusse/googletest-svn.git
+	url = git://github.com/hazelnusse/googletest-git-clone.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_MODULE_PATH ${LIBCONTROL_SOURCE_DIR}/cmake/Modules)
 
 find_package(Eigen3 3.1.2)
 
-option(LIBCONTROL_BUILD_TESTS "Build tests." ON)
+option(LIBCONTROL_BUILD_TESTS "Build tests." OFF)
 set(BUILD_SHARED_LIBS ON)
 
 # Set g++ compiler flags if GNU C++ compiler is being used

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -4,7 +4,16 @@ add_library(control care.cc
                     control_internal_ctrb.cc
                     controllability.cc
                     observability.cc)
-target_link_libraries(control reflapacke)
+
+# see is library reflapacke is installed
+# if not, link against lapacke
+set(USE_REFLAPACKE_LIB "" CACHE INTERNAL "")
+find_library(USE_REFLAPACKE_LIB reflapacke)
+if (USE_REFLAPACKE_LIB)
+    target_link_libraries(control reflapacke)
+else()
+    target_link_libraries(control lapacke)
+endif()
 
 if (LIBCONTROL_BUILD_TESTS)
   add_subdirectory(tests)


### PR DESCRIPTION
Fixed the submodule url for googletest, disabled most build options, fixed lapacke linking error for us mere mortals using ubuntards.
